### PR TITLE
Transaction type enum

### DIFF
--- a/MM4Bank.Domain/Entities/Entity.cs
+++ b/MM4Bank.Domain/Entities/Entity.cs
@@ -8,7 +8,9 @@ namespace MM4Bank.Domain.Entities
 {
     public abstract class Entity
     {
-        public int Id { get; protected set; }
-        public DateTime creadtedAt { get; protected set; } = DateTime.Now;
+        public Guid Id { get; protected set; }
+        public DateTime CreadtedAt { get; protected set; } = DateTime.Now;
+        public DateTime UpdatedAt { get; protected set; } = DateTime.Now;
+        public bool IsActive { get; protected set; }
     }
 }

--- a/MM4Bank.Domain/Entities/Transaction.cs
+++ b/MM4Bank.Domain/Entities/Transaction.cs
@@ -2,25 +2,26 @@
 using MM4Bank.Domain.Validation;
 namespace MM4Bank.Domain.Entities
 {
-    public sealed class Transaction : Entity
+  public sealed class Transaction : Entity
     {
         public decimal Value { get; set; }
         public Account SourceAccount { get; set; }
         public Account TargetAccount { get; set; }
+        public TransactionType Type { get; set; }
 
-        public Transaction(decimal value, Account sourceAccount, Account targetAccount)
+        public Transaction(decimal value, Account sourceAccount, Account targetAccount, TransactionType type)
         {
-            ValidateDomain(value, targetAccount, sourceAccount);
-        }
-
-        private void ValidateDomain(decimal value, Account sourceAccount, Account targetAccount)
-        {
-            DomainExceptionValidation.When(value > sourceAccount.Balance, "Not enough balance on source account.");
-            DomainExceptionValidation.When(value <= 0, "Invalid value, value must be greater than 0");
-
+            ValidateDomain(value, sourceAccount);
             Value = value;
             SourceAccount = sourceAccount;
             TargetAccount = targetAccount;
+            Type = type;
+        }
+
+        private void ValidateDomain(decimal value, Account sourceAccount)
+        {
+            DomainExceptionValidation.When(value > sourceAccount.Balance, "Not enough balance on source account.");
+            DomainExceptionValidation.When(value <= 0, "Invalid value, value must be greater than 0");
         }
     }
 }

--- a/MM4Bank.Domain/Entities/Transaction.cs
+++ b/MM4Bank.Domain/Entities/Transaction.cs
@@ -4,10 +4,10 @@ namespace MM4Bank.Domain.Entities
 {
   public sealed class Transaction : Entity
     {
-        public decimal Value { get; set; }
-        public Account SourceAccount { get; set; }
-        public Account TargetAccount { get; set; }
-        public TransactionType Type { get; set; }
+        public decimal Value { get; private set; }
+        public Account SourceAccount { get; private set; }
+        public Account TargetAccount { get; private set; }
+        public TransactionType Type { get; private set; }
 
         public Transaction(decimal value, Account sourceAccount, Account targetAccount, TransactionType type)
         {

--- a/MM4Bank.Domain/Entities/Transaction.cs
+++ b/MM4Bank.Domain/Entities/Transaction.cs
@@ -2,7 +2,7 @@
 using MM4Bank.Domain.Validation;
 namespace MM4Bank.Domain.Entities
 {
-  public sealed class Transaction : Entity
+    public sealed class Transaction : Entity
     {
         public decimal Value { get; private set; }
         public Account SourceAccount { get; private set; }

--- a/MM4Bank.Domain/Entities/TransactionType.cs
+++ b/MM4Bank.Domain/Entities/TransactionType.cs
@@ -1,0 +1,6 @@
+public enum TransactionType
+{
+    DEPOSIT,
+    TRANSFER,
+    WITHDRAW
+}


### PR DESCRIPTION
Criei um enum para saber se a transação é saque, depósito ou transferência. Daí modifiquei o Transaction para ter uma propriedade desse enum e também o construtor pq tava como middleman e o validate tava desrespeitando o single responsibility principle.